### PR TITLE
Enforce uniqueness of SR users.

### DIFF
--- a/deploy/result.user.index_unique.sql
+++ b/deploy/result.user.index_unique.sql
@@ -1,0 +1,4 @@
+-- Deploy result.user.index_unique
+-- requires: result_user
+
+CREATE UNIQUE INDEX CONCURRENTLY result_user_all_column_idx ON result.user (software_result_id, label, user_class_name, user_id);

--- a/revert/result.user.index_unique.sql
+++ b/revert/result.user.index_unique.sql
@@ -1,0 +1,7 @@
+-- Revert result.user.index_unique
+
+BEGIN;
+
+DROP INDEX result.result_user_all_column_idx;
+
+COMMIT;

--- a/sqitch.plan
+++ b/sqitch.plan
@@ -359,3 +359,5 @@ remove_params_and_inputs_from_software_results [result_software_result] 2014-12-
 
 drop_featurelist_file_id [model_feature_list] 2014-12-18T15:26:31Z Thomas B. Mooney <tmooney@genome.wustl.edu> # drop obsolete column
 @1419272844 2014-12-22T18:27:24Z Thomas B. Mooney <tmooney@genome.wustl.edu># dropped file_id column from feature lists
+
+result.user.index_unique [result_user] 2015-03-05T14:47:59Z Thomas B. Mooney <tmooney@genome.wustl.edu> # only one identical user per SR

--- a/verify/result.user.index_unique.sql
+++ b/verify/result.user.index_unique.sql
@@ -1,0 +1,9 @@
+-- Verify result.user.index_unique
+
+BEGIN;
+
+SELECT 1/count(*) FROM pg_class AS c
+    INNER JOIN pg_namespace AS n ON c.relnamespace = n.oid
+    WHERE n.nspname = 'result' AND c.relkind = 'i' and c.relname = 'result_user_all_column_idx';
+
+ROLLBACK;


### PR DESCRIPTION
#### Features:
- No more errors about finding duplicate users!
- Guaranteed uniqueness assists in analyzing the sponsor/requestor information.
#### Considerations:
- There may be places in the code (outside of SR's `get_with_lock` and `get_or_create`) that are still trying to make duplicates, which could now lead to crashes at commit time.
- There are several indices on this table already.  This one may eliminate the need for some of the others (but dropping those at the same time this one is being created would be ill-advised).
- This index will take a long time to generate.  If it does run across a duplicate, it will fail. We'll then have to drop it and try again.  (Yesterday I deleted _all_ duplicates in the table that I could find, so this would mean some escaped or new ones are being created.)
