### PR TITLE
Add new table for storing Genome::Qc::Config

### DIFF
--- a/deploy/add_table_for_qc_config.sql
+++ b/deploy/add_table_for_qc_config.sql
@@ -1,0 +1,17 @@
+-- Deploy add_table_for_qc_config
+-- requires: config_schema
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS config.qc (
+    id character varying(64) NOT NULL,
+    name text NOT NULL UNIQUE,
+    type text NULL,
+    config JSON NOT NULL,
+    created_by character varying(255) NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT config_qc_pk PRIMARY KEY(id)
+);
+
+COMMIT;

--- a/revert/add_table_for_qc_config.sql
+++ b/revert/add_table_for_qc_config.sql
@@ -1,0 +1,7 @@
+-- Revert add_table_for_qc_config
+
+BEGIN;
+
+DROP TABLE IF EXISTS config.qc;
+
+COMMIT;

--- a/sqitch.plan
+++ b/sqitch.plan
@@ -362,3 +362,5 @@ drop_featurelist_file_id [model_feature_list] 2014-12-18T15:26:31Z Thomas B. Moo
 
 result.user.index_unique [result_user] 2015-03-05T14:47:59Z Thomas B. Mooney <tmooney@genome.wustl.edu> # only one identical user per SR
 @apipe-ci/genome-sqitch-13 2015-09-22T16:09:52Z Apipe Tester <apipe-tester@linuscs125> # apipe-ci/genome-sqitch-13
+
+add_table_for_qc_config [config_schema] 2015-09-22T16:10:10Z Susanna Siebert <ssiebert@genome.wustl.edu> # This change adds a table for storing Genome::Qc::Config

--- a/verify/add_table_for_qc_config.sql
+++ b/verify/add_table_for_qc_config.sql
@@ -1,0 +1,9 @@
+-- Verify add_table_for_qc_config
+
+BEGIN;
+
+SELECT id, name, type, config, created_by, created_at, updated_at
+FROM config.qc
+WHERE FALSE;
+
+ROLLBACK;


### PR DESCRIPTION
``` perl
class Genome::Qc::Config {
    is => [
        'Genome::Utility::ObjectWithTimestamps',
        'Genome::Utility::ObjectWithCreatedBy',
        'Genome::Searchable',
    ],
    table_name => 'config.qc',
    id_by => [
        id => {
            is => 'Text',
            len => 64,
        }
    ],
    has => [
        name => {
            is => 'Text',
        },
        type => {
            is => 'String',
            is_optional => 1,
            valid_values => ['wgs', 'exome'],
        },
        config => {
            is => 'Text',
        }
    ],
    schema_name => 'GMSchema',
    data_source => 'Genome::DataSource::GMSchema',
    id_generator => '-uuid',
};
```
