### PR TITLE
Allow null values in model.subject_class_name

### DIFF
--- a/deploy/model.model.subject_class_name.allow_null.sql
+++ b/deploy/model.model.subject_class_name.allow_null.sql
@@ -1,0 +1,8 @@
+-- Deploy model.model.subject_class_name.allow_null
+-- requires: config.analysismenu_item.status
+
+BEGIN;
+
+    ALTER TABLE model.model ALTER COLUMN subject_class_name DROP NOT NULL;
+
+COMMIT;

--- a/revert/model.model.subject_class_name.allow_null.sql
+++ b/revert/model.model.subject_class_name.allow_null.sql
@@ -1,0 +1,7 @@
+-- Revert model.model.subject_class_name.allow_null
+
+BEGIN;
+
+    ALTER TABLE model.model ALTER COLUMN subject_class_name SET NOT NULL;
+
+COMMIT;

--- a/sqitch.plan
+++ b/sqitch.plan
@@ -371,3 +371,5 @@ set_permissions_for_qc_config [add_table_for_qc_config] 2015-09-29T20:02:55Z Sus
 
 config.analysismenu_item.status [config_analysismenu_item] 2015-10-12T21:11:09Z Thomas B. Mooney <tmooney@genome.wustl.edu># Add status to analysis menu items.
 @apipe-ci/genome-sqitch-16 2015-10-28T19:17:38Z Apipe Tester <apipe-tester@linuscs125> # apipe-ci/genome-sqitch-16
+
+model.model.subject_class_name.allow_null [config.analysismenu_item.status] 2016-02-08T20:40:16Z Michael Kiwala <mkiwala@genome.wustl.edu> # Allow nullable values on model.subject_class_name

--- a/verify/model.model.subject_class_name.allow_null.sql
+++ b/verify/model.model.subject_class_name.allow_null.sql
@@ -1,0 +1,11 @@
+-- Verify model.model.subject_class_name.allow_null
+
+BEGIN;
+
+    SELECT 1/count(*)
+        FROM pg_attribute
+        WHERE attrelid = 'model.model'::regclass
+          AND attname = 'subject_class_name'
+          AND attnotnull = FALSE;
+
+ROLLBACK;


### PR DESCRIPTION
We now delegate to the subject table for the subject class name.

This PR is in preparation to stop setting `subject_class_name` in Genome::Model::create().
